### PR TITLE
build: ignore flake8-annotations rules

### DIFF
--- a/pyproject.toml.jinja
+++ b/pyproject.toml.jinja
@@ -133,6 +133,9 @@ show_error_codes = true
 select = ["ALL"]
 ignore = [
     "A003", # flake8-builtins - class attribute {name} is shadowing a python builtin
+    "ANN101", # flake8-annotations - missing type annotation for self in method
+    "ANN102", # flake8-annotations - missing type annotation for cls in classmethod
+    "ANN401", # flake8-annotations - dynamically typed expressions (typing.Any) are disallowed
     "B010", # flake8-bugbear - do not call setattr with a constant attribute value
     "D100", # pydocstyle - missing docstring in public module
     "D101", # pydocstyle - missing docstring in public class


### PR DESCRIPTION
[//]: # "By submitting this pull request, you agree to:"
[//]: # "- follow [Jolt's Code of Conduct](https://github.com/jolt-org/.github/blob/main/CODE_OF_CONDUCT.md)"
[//]: # "- follow [PSFs's Code of Conduct](https://www.python.org/psf/conduct/)"
[//]: # "- follow [Jolt's contribution guidelines](https://github.com/jolt-org/.github/blob/main/CONTRIBUTING.md)"

### Pull Request Checklist

- [ ] New code has 100% test coverage
- [ ] (If applicable) The prose documentation has been updated to reflect the changes introduced by this PR
- [ ] (If applicable) The reference documentation has been updated to reflect the changes introduced by this PR
- [ ] Pre-Commit Checks were ran and passed
- [ ] Tests were ran and passed

### Description
[//]: # "Please describe your pull request for new release changelog purposes"

- build: ignore flake8-annotations rules
- `101` & `102` enforce explicit typing of `self` and `cls` in methods, which I think we can do without.
- The flake8-annotations project ignores these themselves: https://github.com/sco1/flake8-annotations/blob/7fe0eb3d308db145ffca7fe6fe2dd9280af5a9e5/.flake8#L15
- `401` forbids typing anything as `Any`.

### Close Issue(s)
[//]: # "Please add in issue numbers this pull request will close, if applicable"
[//]: # "Examples: Fixes #4321 or Closes #1234"

- 
